### PR TITLE
ProphAsm 0.1.2

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,11 @@
+BasedOnStyle: Google
+Language: Cpp
+Standard: Cpp11
+AlignConsecutiveAssignments: true
+SortIncludes: true
+UseTab: Never
+IndentWidth: 4
+IndentCaseLabels: true
+NamespaceIndentation: None
+ColumnLimit: 100
+

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,33 @@
+# vim: set ft=yaml ts=2 sts=2 sw=2 expandtab:
+cff-version: 1.2.0
+title: ProphAsm
+message: "If you use this software, please cite both the article from preferred-citation and the software itself."
+type: software
+authors:
+  - family-names: Břinda
+    given-names: Karel
+    email: karel.brinda@inria.fr
+    orcid: "https://orcid.org/0000-0003-0200-557X"
+doi: 10.5281/zenodo.3887034
+repository-code: 'https://github.com/prophyle/prophasm'
+license: MIT
+preferred-citation:
+  authors:
+    - family-names: Břinda
+      given-names: Karel
+      email: karel.brinda@inria.fr
+      orcid: "https://orcid.org/0000-0003-0200-557X"
+    - family-names: Baym
+      given-names: Michael
+      email: baym@hms.harvard.edu
+      orcid: "https://orcid.org/0000-0003-1303-5598"
+    - family-names: Kucherov
+      given-names: Gregory
+      email: gregory.kucherov@univ-eiffel.fr
+      orcid: "https://orcid.org/0000-0001-5899-5424"
+  type: article
+  title: "Simplitigs as an efficient and scalable representation of de Bruijn graphs"
+  year: 2021
+  journal: Genome Biology
+  volume: 22
+  doi: 10.1186/s13059-021-02297-z

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,32 +1,37 @@
 # vim: set ft=yaml ts=2 sts=2 sw=2 expandtab:
+# This CITATION.cff file was generated with cffinit.
+# Visit https://bit.ly/cffinit to generate yours today!
+
 cff-version: 1.2.0
 title: ProphAsm
-message: "If you use this software, please cite both the article from preferred-citation and the software itself."
+message: >-
+  If you use this software, please cite both the article
+  from preferred-citation and the software itself.
 type: software
 authors:
   - family-names: Břinda
     given-names: Karel
     email: karel.brinda@inria.fr
-    orcid: "https://orcid.org/0000-0003-0200-557X"
-doi: 10.5281/zenodo.3887034
+    orcid: 'https://orcid.org/0000-0003-0200-557X'
 repository-code: 'https://github.com/prophyle/prophasm'
 license: MIT
+doi: 10.5281/zenodo.3887034
 preferred-citation:
   authors:
     - family-names: Břinda
       given-names: Karel
       email: karel.brinda@inria.fr
-      orcid: "https://orcid.org/0000-0003-0200-557X"
+      orcid: 'https://orcid.org/0000-0003-0200-557X'
     - family-names: Baym
       given-names: Michael
       email: baym@hms.harvard.edu
-      orcid: "https://orcid.org/0000-0003-1303-5598"
+      orcid: 'https://orcid.org/0000-0003-1303-5598'
     - family-names: Kucherov
       given-names: Gregory
       email: gregory.kucherov@univ-eiffel.fr
-      orcid: "https://orcid.org/0000-0001-5899-5424"
+      orcid: 'https://orcid.org/0000-0001-5899-5424'
   type: article
-  title: "Simplitigs as an efficient and scalable representation of de Bruijn graphs"
+  title: Simplitigs as an efficient and scalable representation of de Bruijn graphs
   year: 2021
   journal: Genome Biology
   volume: 22

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License
 
-Copyright (c) 2016-2017 Karel Brinda <kbrinda@hsph.harvard.edu>
+Copyright (c) 2016-2020 Karel Brinda <karel.brinda@hms.harvard.edu>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,9 @@
 The MIT License
 
-Copyright (c) 2016-2020 Karel Brinda <karel.brinda@hms.harvard.edu>
+Copyright (c) 2022-     Inria
+              2017-2021 Harvard Medical School
+              2017-2021 Harvard T.H. Chan School of Public Health
+              2015-2016 Universite Paris-Est
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ test:
 	$(MAKE) -C tests
 
 format:
-	clang-format -i src/*.cpp src/*.h
+	clang-format -i src/*.cpp #src/*.h
 
 readme:
 	f=$$(mktemp);\

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all help clean test prophasm readme
+.PHONY: all help clean test prophasm readme format
 
 SHELL=/usr/bin/env bash -eo pipefail
 
@@ -14,6 +14,9 @@ help: ## Print help message
 
 test:
 	$(MAKE) -C tests
+
+format:
+	clang-format -i src/*.cpp src/*.h
 
 readme:
 	f=$$(mktemp);\

--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ USAGE-BEGIN
 -->
 ```
 Program:  prophasm (a greedy assembler for k-mer set compression)
-Version:  0.1.0
-Contact:  Karel Brinda <kbrinda@hsph.harvard.edu>
+Version:  0.1.1
+Contact:  Karel Brinda <karel.brinda@hms.harvard.edu>
 
 Usage:    prophasm [options]
 
@@ -92,7 +92,6 @@ Command-line parameters:
 Note that '-' can be used for standard input/output.
 
 ```
-
 <!---
 USAGE-END
 -->
@@ -115,7 +114,7 @@ def extend_simplitig_forward (K, simplitig):
 				S.remove (reverse_complement (kmer))
 				break
 	return S, s
- 
+
 def get_maximal_simplitig (K, initial_kmer):
 	simplitig = initial_kmer
 	K.remove (initial_kmer)
@@ -124,7 +123,7 @@ def get_maximal_simplitig (K, initial_kmer):
 	simplitig = reverse_completent (simplitig)
 	K, simplitig = extend_simplitig_forward (K, simplitig)
 	return K, simplitig
- 
+
 def compute_simplitigs (kmers):
 	K = set()
 	for kmer in kmers:

--- a/README.md
+++ b/README.md
@@ -90,26 +90,26 @@ Set operations:
 USAGE-BEGIN
 -->
 ```
-Program:  prophasm (a greedy assembler for k-mer set compression)
-Version:  0.1.1
+Program:  prophasm (computation of simplitigs and k-mer set operations)
+Version:  0.1.2
 Contact:  Karel Brinda <karel.brinda@hms.harvard.edu>
 
 Usage:    prophasm [options]
 
-Examples: prophasm -k 15 -i f1.fa -i f2.fa -x fx.fa
-             - compute intersection of f1 and f2
-          prophasm -k 15 -i f1.fa -i f2.fa -x fx.fa -o g1.fa -o g2.fa
-             - compute intersection of f1 and f2, and subtract it from them
-          prophasm -k 15 -i f1.fa -o g1.fa
-             - re-assemble f1 to g1
+Examples: prophasm -k 31 -i ref.fa -o simplitigs.fa
+           - compute simplitigs of ref.fa
+          prophasm -k 31 -i ref1.fa -i ref2.fa -x inter.fa
+           - intersect the k-mers sets of ref1 and ref2
+          prophasm -k 31 -i ref1.fa -i ref2.fa -x inter.fa -o dif1.fa -o dif2.fa
+           - intersect ref1 and ref2, and compute the set differences
 
 Command-line parameters:
- -k INT   K-mer size.
- -i FILE  Input FASTA file (can be used multiple times).
- -o FILE  Output FASTA file (if used, must be used as many times as -i).
- -x FILE  Compute intersection, subtract it, save it.
- -s FILE  Output file with k-mer statistics.
- -S       Silent mode.
+ -k INT   k-mer length (from [1, 32])
+ -i FILE  input FASTA file (can be used multiple times)
+ -o FILE  output FASTA file (if used, must be used as many times as -i)
+ -x FILE  compute intersection, subtract it, save it
+ -s FILE  output file with k-mer statistics
+ -S       silent mode
 
 Note that '-' can be used for standard input/output.
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 * [Cite](#cite)
 * [Prerequisities](#prerequisities)
 * [Getting started](#getting-started)
+* [How to use](#how-to-use)
 * [Links](#links)
 * [Issues](#issues)
 * [Changelog](#changelog)
@@ -78,13 +79,16 @@ Compute simplitigs:
 ./prophasm -k 15 -i tests/test1.fa -o simplitigs.fa
 ```
 
+
+## How to use
+
 Set operations:
 ```
 ./prophasm -k 15 -i tests/test1.fa -i tests/test2.fa -o _out1.fa -o _out2.fa -x _intersect.fa -s _stats.tsv
    ```
 
 
-## Command line parameters
+## Command-line arguments
 
 <!---
 USAGE-BEGIN
@@ -92,7 +96,7 @@ USAGE-BEGIN
 ```
 Program:  prophasm (computation of simplitigs and k-mer set operations)
 Version:  0.1.2
-Contact:  Karel Brinda <karel.brinda@hms.harvard.edu>
+Contact:  Karel Brinda <karel.brinda@inria.fr>
 
 Usage:    prophasm [options]
 

--- a/src/prophasm.cpp
+++ b/src/prophasm.cpp
@@ -327,11 +327,11 @@ int kmers_from_fasta(const std::string &fasta_fn, _set_T &set, int32_t k, FILE *
 
     typename _set_T::value_type nkmer;
 
-    int64_t ns=0;
-    int64_t cl=0;
+    int64_t ns = 0;
+    int64_t cl = 0;
     for (int32_t seqid = 0; (l = kseq_read(seq)) >= 0; seqid++) {
-		ns++;
-		cl+=seq->seq.l;
+        ns++;
+        cl += seq->seq.l;
         for (char *kmer = seq->seq.s; kmer < (seq->seq.s) + (seq->seq.l) - k + 1; kmer++) {
             int c = encode_canonical(kmer, k, nkmer);
             if (c == 0) {
@@ -342,7 +342,6 @@ int kmers_from_fasta(const std::string &fasta_fn, _set_T &set, int32_t k, FILE *
         }
     }
 
-
     if (fstats) {
         fprintf(fstats, "%s\t%lu\n", fasta_fn.c_str(), set.size());
     }
@@ -352,8 +351,8 @@ int kmers_from_fasta(const std::string &fasta_fn, _set_T &set, int32_t k, FILE *
     gzclose(fp);
 
     if (verbose) {
-        std::cerr << "      #kmers=" << set.size() << ", NS=" << ns << ", CL="
-                  << cl << " bp (" << round(cl*1e-4)*1e-2 << " Mbp)" << std::endl;
+        std::cerr << "      #kmers=" << set.size() << ", NS=" << ns << ", CL=" << cl << " bp ("
+                  << round(cl * 1e-4) * 1e-2 << " Mbp)" << std::endl;
     }
 
     return 0;
@@ -510,8 +509,8 @@ int assemble(const std::string &fasta_fn, _set_T &set, int32_t k, FILE *fstats, 
     const int64_t cl = kmers + ns * (k - 1);
     if (verbose) {
         std::cerr << "   simplitig computation finished (" << fasta_fn << ")" << std::endl;
-        std::cerr << "      #kmers=" << kmers << ", NS=" << ns << ", CL="
-                  << cl << " bp (" << round(cl*1e-4)*1e-2 << " Mbp)" << std::endl;
+        std::cerr << "      #kmers=" << kmers << ", NS=" << ns << ", CL=" << cl << " bp ("
+                  << round(cl * 1e-4) * 1e-2 << " Mbp)" << std::endl;
     }
 
     return 0;
@@ -651,8 +650,7 @@ int main(int argc, char *argv[]) {
             find_intersection(full_sets, intersection);
             intersection_size = intersection.size();
             if (verbose) {
-                std::cerr << "   intersection: #kmers=" << intersection_size
-                          << std::endl;
+                std::cerr << "   intersection: #kmers=" << intersection_size << std::endl;
             }
             if (compute_differences) {
                 if (verbose) {
@@ -667,9 +665,9 @@ int main(int argc, char *argv[]) {
                 out_sizes.insert(out_sizes.end(), full_sets[i].size());
                 assert(in_sizes[i] == out_sizes[i] + intersection_size);
                 if (verbose) {
-                    std::cerr << "   input: #kmers=" << in_sizes[i]
-                              << ", output: #kmers=" << out_sizes[i]
-							  //<< ", intersection size: " << intersection_size << " k-mers"
+                    std::cerr << "   input: #kmers=" << in_sizes[i] << ", output: #kmers="
+                              << out_sizes[i]
+                              //<< ", intersection size: " << intersection_size << " k-mers"
                               << std::endl;
                 }
             }

--- a/src/prophasm.cpp
+++ b/src/prophasm.cpp
@@ -500,7 +500,7 @@ int assemble(const std::string &fasta_fn, _set_T &set, int32_t k, FILE *fstats, 
 
     fclose(file);
 
-    const int64_t ns = simplitig_id;
+    const int64_t ns = simplitig_id - 1;
     const int64_t cl = kmers + ns * (k - 1);
     if (verbose) {
         std::cerr << "   simplitig computation finished (" << ns << " simplitigs, "

--- a/src/prophasm.cpp
+++ b/src/prophasm.cpp
@@ -307,7 +307,7 @@ template <typename _set_T>
 int kmers_from_fasta(const std::string &fasta_fn, _set_T &set, int32_t k, FILE *fstats,
                      bool verbose) {
     if (verbose) {
-        std::cerr << "   loading " << fasta_fn << std::endl;
+        std::cerr << "   fasta loading (" << fasta_fn << ")" << std::endl;
     }
 
     set.clear();
@@ -327,10 +327,11 @@ int kmers_from_fasta(const std::string &fasta_fn, _set_T &set, int32_t k, FILE *
 
     typename _set_T::value_type nkmer;
 
+    int64_t ns=0;
+    int64_t cl=0;
     for (int32_t seqid = 0; (l = kseq_read(seq)) >= 0; seqid++) {
-        // std::cerr << "kmers from fasta" << std::endl;
-
-        // std::cerr << "starting iterator" << std::endl;
+		ns++;
+		cl+=seq->seq.l;
         for (char *kmer = seq->seq.s; kmer < (seq->seq.s) + (seq->seq.l) - k + 1; kmer++) {
             int c = encode_canonical(kmer, k, nkmer);
             if (c == 0) {
@@ -341,6 +342,7 @@ int kmers_from_fasta(const std::string &fasta_fn, _set_T &set, int32_t k, FILE *
         }
     }
 
+
     if (fstats) {
         fprintf(fstats, "%s\t%lu\n", fasta_fn.c_str(), set.size());
     }
@@ -348,6 +350,11 @@ int kmers_from_fasta(const std::string &fasta_fn, _set_T &set, int32_t k, FILE *
 
     kseq_destroy(seq);
     gzclose(fp);
+
+    if (verbose) {
+        std::cerr << "      #kmers=" << set.size() << ", NS=" << ns << ", CL="
+                  << cl << " bp (" << round(cl*1e-4)*1e-2 << " Mbp)" << std::endl;
+    }
 
     return 0;
 }
@@ -502,7 +509,8 @@ int assemble(const std::string &fasta_fn, _set_T &set, int32_t k, FILE *fstats, 
     const int64_t ns = simplitig_id - 1;
     const int64_t cl = kmers + ns * (k - 1);
     if (verbose) {
-        std::cerr << "   simplitig computation finished; #kmers=" << kmers << ", NS=" << ns << ", CL="
+        std::cerr << "   simplitig computation finished (" << fasta_fn << ")" << std::endl;
+        std::cerr << "      #kmers=" << kmers << ", NS=" << ns << ", CL="
                   << cl << " bp (" << round(cl*1e-4)*1e-2 << " Mbp)" << std::endl;
     }
 

--- a/src/prophasm.cpp
+++ b/src/prophasm.cpp
@@ -58,8 +58,8 @@ Todo:
 typedef uint64_t nkmer_t;
 typedef std::set<nkmer_t> set_t;
 
-const int32_t fasta_line_length=60;
 const int32_t max_simplitig_length=10000000;
+const int32_t fasta_line_length=max_simplitig_length; // do not break fasta lines
 const int32_t max_allowed_kmer_length=sizeof(nkmer_t)*4;
 //const int32_t default_k=31;
 

--- a/src/prophasm.cpp
+++ b/src/prophasm.cpp
@@ -34,8 +34,8 @@ Description:
         de-Bruijn graphs.
 
 Todo:
-        * Find a library for sets of integers bigger than uint64_t (to support k-mers longer than
-32).
+        * Find a library for sets of integers bigger than uint64_t
+          (to support k-mers longer than 32).
         * Optimize loading FASTA files.
 */
 #include <getopt.h>
@@ -370,8 +370,6 @@ int32_t find_intersection(const std::vector<_set_T> &sets, _set_T &intersection)
     int32_t min   = std::numeric_limits<int32_t>::max();
     int32_t i_min = -1;
 
-    // std::cerr << "searching min" << std::endl;
-
     for (int32_t i = 0; i < static_cast<int32_t>(sets.size()); i++) {
         if (static_cast<int32_t>(sets[i].size()) < min) {
             min   = sets[i].size();
@@ -385,11 +383,7 @@ int32_t find_intersection(const std::vector<_set_T> &sets, _set_T &intersection)
     /*
             2) Take it as the intersection.
     */
-
-    // std::cerr << "2" << std::endl;
-
     intersection.clear();
-    // std::cerr << "2.1" << std::endl;
     std::copy(sets[i_min].cbegin(), sets[i_min].cend(),
               std::inserter(intersection, intersection.end()));
 
@@ -468,7 +462,6 @@ int assemble(const std::string &fasta_fn, _set_T &set, int32_t k, FILE *fstats, 
             bool extending = true;
 
             // std::cerr << "central k-mer: " << central_kmer_string << std::endl;
-
             while (extending) {
                 for (int32_t i = 0; i < k; i++) {
                     kmer_str[i] = kmer_str[i + 1];
@@ -501,8 +494,6 @@ int assemble(const std::string &fasta_fn, _set_T &set, int32_t k, FILE *fstats, 
                 }
             }
         }
-
-        // std::cerr << "====================" << std::endl;
 
         std::stringstream ss;
         ss << "c" << simplitig_id;

--- a/src/prophasm.cpp
+++ b/src/prophasm.cpp
@@ -60,7 +60,6 @@ typedef uint64_t nkmer_t;
 typedef std::set<nkmer_t> set_t;
 
 const int32_t max_simplitig_length    = 10000000;
-const int32_t fasta_line_length       = max_simplitig_length;  // do not break fasta lines
 const int32_t max_allowed_kmer_length = sizeof(nkmer_t) * 4;
 // const int32_t default_k=31;
 
@@ -294,12 +293,7 @@ struct simplitig_t {
             fprintf(fasta_file, ">%s %s\n", simplitig_name, comment);
         }
 
-        char print_buffer[fasta_line_length + 1] = {0};
-
-        for (char *p = l_ext; p < r_ext; p += fasta_line_length) {
-            strncpy(print_buffer, p, fasta_line_length);
-            fprintf(fasta_file, "%s\n", print_buffer);
-        }
+        fprintf(fasta_file, "%s\n", l_ext);
 
         return 0;
     }

--- a/src/prophasm.cpp
+++ b/src/prophasm.cpp
@@ -502,8 +502,8 @@ int assemble(const std::string &fasta_fn, _set_T &set, int32_t k, FILE *fstats, 
     const int64_t ns = simplitig_id - 1;
     const int64_t cl = kmers + ns * (k - 1);
     if (verbose) {
-        std::cerr << "   simplitig computation finished (" << ns << " simplitigs, "
-                  << cl / (1024.0 * 1024.0) << " Mbp)" << std::endl;
+        std::cerr << "   simplitig computation finished; #kmers=" << kmers << ", NS=" << ns << ", CL="
+                  << cl << " bp (" << round(cl*1e-4)*1e-2 << " Mbp)" << std::endl;
     }
 
     return 0;
@@ -643,7 +643,7 @@ int main(int argc, char *argv[]) {
             find_intersection(full_sets, intersection);
             intersection_size = intersection.size();
             if (verbose) {
-                std::cerr << "   intersection size: " << intersection_size << " k-mers"
+                std::cerr << "   intersection: #kmers=" << intersection_size
                           << std::endl;
             }
             if (compute_differences) {
@@ -659,9 +659,9 @@ int main(int argc, char *argv[]) {
                 out_sizes.insert(out_sizes.end(), full_sets[i].size());
                 assert(in_sizes[i] == out_sizes[i] + intersection_size);
                 if (verbose) {
-                    std::cerr << "   input size: " << in_sizes[i]
-                              << " k-mers, output size: " << out_sizes[i]
-                              << " k-mers, intersection size: " << intersection_size << " k-mers"
+                    std::cerr << "   input: #kmers=" << in_sizes[i]
+                              << ", output: #kmers=" << out_sizes[i]
+							  //<< ", intersection size: " << intersection_size << " k-mers"
                               << std::endl;
                 }
             }

--- a/src/prophasm.cpp
+++ b/src/prophasm.cpp
@@ -65,6 +65,7 @@ const int32_t max_allowed_kmer_length=sizeof(nkmer_t)*4;
 
 static const uint8_t nt4_nt256[] = "ACGTN";
 
+// clang-format off
 static const uint8_t nt256_nt4[] = {
 		4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4,
 		4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4,
@@ -83,6 +84,7 @@ static const uint8_t nt256_nt4[] = {
 		4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4,
 		4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4
 	};
+// clang-format on
 
 
 KSEQ_INIT(gzFile, gzread)

--- a/src/prophasm.cpp
+++ b/src/prophasm.cpp
@@ -59,7 +59,7 @@ typedef uint64_t nkmer_t;
 typedef std::set<nkmer_t> set_t;
 
 const int32_t fasta_line_length=60;
-const int32_t max_contig_length=10000000;
+const int32_t max_simplitig_length=10000000;
 const int32_t max_allowed_kmer_length=sizeof(nkmer_t)*4;
 //const int32_t default_k=31;
 
@@ -219,16 +219,16 @@ void debug_print_kmer_set(_set_T &set, int k, bool verbose){
 }
 
 
-struct contig_t{
+struct simplitig_t{
 	int32_t k;
 
-	/* contig buffer */
+	/* simplitig buffer */
 	char *seq_buffer;
 
-	/* the first position of the contig */
+	/* the first position of the simplitig */
 	char *l_ext;
 
-	/* the last position of the contig +1 (semiopen ) */
+	/* the last position of the simplitig +1 (semiopen ) */
 	char *r_ext;
 
 	/* min possible value of l_ext */
@@ -237,17 +237,17 @@ struct contig_t{
 	/* max possible value of l_ext */
 	char *r_ext_border;
 
-	contig_t(uint32_t _k){
+	simplitig_t(uint32_t _k){
 		this->k=_k;
-		seq_buffer=new char[k+2*max_contig_length+1]();
+		seq_buffer=new char[k+2*max_simplitig_length+1]();
 		l_ext_border=seq_buffer;
-		r_ext_border=seq_buffer+2*max_contig_length;
+		r_ext_border=seq_buffer+2*max_simplitig_length;
 	}
 
-	int32_t new_contig(const char *base_kmer){
+	int32_t new_simplitig(const char *base_kmer){
 		assert(static_cast<int32_t>(strlen(base_kmer))==k);
 
-		l_ext = r_ext = &seq_buffer[max_contig_length];
+		l_ext = r_ext = &seq_buffer[max_simplitig_length];
 		*r_ext='\0';
 
 		for(int32_t i=0;i<k;i++){
@@ -281,7 +281,7 @@ struct contig_t{
 		return 0;
 	}
 
-	~contig_t(){
+	~simplitig_t(){
 		delete[] seq_buffer;
 	}
 
@@ -289,11 +289,11 @@ struct contig_t{
 		return (r_ext>=r_ext_border) || (l_ext<=l_ext_border);
 	}
 
-	int32_t print_to_fasta(FILE* fasta_file, const char* contig_name, const char *comment=nullptr) const {
+	int32_t print_to_fasta(FILE* fasta_file, const char* simplitig_name, const char *comment=nullptr) const {
 		if (comment==nullptr){
-			fprintf(fasta_file,">%s\n",contig_name);
+			fprintf(fasta_file,">%s\n",simplitig_name);
 		} else {
-			fprintf(fasta_file,">%s %s\n",contig_name,comment);
+			fprintf(fasta_file,">%s %s\n",simplitig_name,comment);
 		}
 
 		char print_buffer[fasta_line_length+1]={0};
@@ -452,11 +452,11 @@ int assemble(const std::string &fasta_fn, _set_T &set, int32_t k, FILE* fstats, 
 		test_file(file, fasta_fn);
 	}
 	char kmer_str[max_allowed_kmer_length+1];
-	contig_t contig(k);
+	simplitig_t simplitig(k);
 	const std::vector<char> nucls = {'A','C','G','T'};
 
 	//int32_t i=0;
-	int32_t contig_id=1;
+	int32_t simplitig_id=1;
 	while(set.size()>0){
 
 		const auto central_nkmer=*(set.begin());
@@ -464,7 +464,7 @@ int assemble(const std::string &fasta_fn, _set_T &set, int32_t k, FILE* fstats, 
 
 		std::string central_kmer_string;
 		decode_kmer(central_nkmer,k,central_kmer_string);
-		contig.new_contig(central_kmer_string.c_str());
+		simplitig.new_simplitig(central_kmer_string.c_str());
 
 		typename _set_T::value_type nkmer;
 
@@ -504,17 +504,17 @@ int assemble(const std::string &fasta_fn, _set_T &set, int32_t k, FILE* fstats, 
 					if(set.count( nkmer )){
 						//std::cerr << "extending " << c << std::endl;
 						//debug_print_kmer_set(set,k);
-						//std::cerr << std::string(contig.l_ext) << c << std::endl;
+						//std::cerr << std::string(simplitig.l_ext) << c << std::endl;
 						//std::cerr << std::endl;
 						if(direction==0){
-							contig.r_extend(c);
+							simplitig.r_extend(c);
 						}
 						else{
-							contig.l_extend(c);
+							simplitig.l_extend(c);
 						}
 						set.erase(nkmer);
 
-						if(!contig.is_full()){
+						if(!simplitig.is_full()){
 							extending=true;
 						}
 						break;
@@ -526,16 +526,16 @@ int assemble(const std::string &fasta_fn, _set_T &set, int32_t k, FILE* fstats, 
 		//std::cerr << "====================" << std::endl;
 
 		std::stringstream ss;
-		ss<<"c"<<contig_id;
-		const std::string contig_name(ss.str());
-		contig.print_to_fasta(file,contig_name.c_str());
-		contig_id++;
+		ss<<"c"<<simplitig_id;
+		const std::string simplitig_name(ss.str());
+		simplitig.print_to_fasta(file,simplitig_name.c_str());
+		simplitig_id++;
 	}
 
 	fclose(file);
 
 	if(verbose){
-		std::cerr << "   assembly finished (" << contig_id << " contigs)" << std::endl;
+		std::cerr << "   assembly finished (" << simplitig_id << " simplitigs)" << std::endl;
 	}
 
 	return 0;

--- a/src/prophasm.cpp
+++ b/src/prophasm.cpp
@@ -1,67 +1,68 @@
 /*
-	The MIT License
+        The MIT License
 
-	Copyright (c) 2016-2020 Karel Brinda <karel.brinda@hms.harvard.edu>
+        Copyright (c) 2016-2020 Karel Brinda <karel.brinda@hms.harvard.edu>
 
-	Permission is hereby granted, free of charge, to any person obtaining
-	a copy of this software and associated documentation files (the
-	"Software"), to deal in the Software without restriction, including
-	without limitation the rights to use, copy, modify, merge, publish,
-	distribute, sublicense, and/or sell copies of the Software, and to
-	permit persons to whom the Software is furnished to do so, subject to
-	the following conditions:
+        Permission is hereby granted, free of charge, to any person obtaining
+        a copy of this software and associated documentation files (the
+        "Software"), to deal in the Software without restriction, including
+        without limitation the rights to use, copy, modify, merge, publish,
+        distribute, sublicense, and/or sell copies of the Software, and to
+        permit persons to whom the Software is furnished to do so, subject to
+        the following conditions:
 
-	The above copyright notice and this permission notice shall be
-	included in all copies or substantial portions of the Software.
+        The above copyright notice and this permission notice shall be
+        included in all copies or substantial portions of the Software.
 
-	THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-	EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-	MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-	NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
-	BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
-	ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-	CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-	SOFTWARE.
+        THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+        EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+        MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+        NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+        BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+        ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+        CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+        SOFTWARE.
 */
 
 /*
 
 Description:
 
-	Get k-mer sets from FASTA files, extract the intersection, and
-	assemble all the resulting k-mer sets into simplitigs. The assembly is
-	done by greedy enumeration of disjoint paths in the corresponding
-	de-Bruijn graphs.
+        Get k-mer sets from FASTA files, extract the intersection, and
+        assemble all the resulting k-mer sets into simplitigs. The assembly is
+        done by greedy enumeration of disjoint paths in the corresponding
+        de-Bruijn graphs.
 
 Todo:
-	* Find a library for sets of integers bigger than uint64_t (to support k-mers longer than 32).
-	* Optimize loading FASTA files.
+        * Find a library for sets of integers bigger than uint64_t (to support k-mers longer than
+32).
+        * Optimize loading FASTA files.
 */
-#include "kseq.h"
-#include "version.h"
-
+#include <getopt.h>
 #include <zlib.h>
 
+#include <algorithm>
+#include <cassert>
 #include <cinttypes>
 #include <cstdio>
 #include <iostream>
 #include <limits>
-#include <vector>
-#include <algorithm>
 #include <set>
-#include <cassert>
 #include <sstream>
 #include <unordered_set>
-#include <getopt.h>
+#include <vector>
 
-//typedef __uint128_t nkmer_t;
+#include "kseq.h"
+#include "version.h"
+
+// typedef __uint128_t nkmer_t;
 typedef uint64_t nkmer_t;
 typedef std::set<nkmer_t> set_t;
 
-const int32_t max_simplitig_length=10000000;
-const int32_t fasta_line_length=max_simplitig_length; // do not break fasta lines
-const int32_t max_allowed_kmer_length=sizeof(nkmer_t)*4;
-//const int32_t default_k=31;
+const int32_t max_simplitig_length    = 10000000;
+const int32_t fasta_line_length       = max_simplitig_length;  // do not break fasta lines
+const int32_t max_allowed_kmer_length = sizeof(nkmer_t) * 4;
+// const int32_t default_k=31;
 
 static const uint8_t nt4_nt256[] = "ACGTN";
 
@@ -86,638 +87,610 @@ static const uint8_t nt256_nt4[] = {
 	};
 // clang-format on
 
-
 KSEQ_INIT(gzFile, gzread)
 
-
-void print_help(){
-	std::cerr <<
-		"\n" <<
-		"Program:  prophasm (a greedy assembler for k-mer set compression)\n" <<
-		"Version:  " VERSION "\n" <<
-		"Contact:  Karel Brinda <karel.brinda@hms.harvard.edu>\n" <<
-		"\n" <<
-		"Usage:    prophasm [options]\n" <<
-		"\n" <<
-		"Examples: prophasm -k 15 -i f1.fa -i f2.fa -x fx.fa\n" <<
-		"             - compute intersection of f1 and f2\n" <<
-		"          prophasm -k 15 -i f1.fa -i f2.fa -x fx.fa -o g1.fa -o g2.fa\n" <<
-		"             - compute intersection of f1 and f2, and subtract it from them\n" <<
-		"          prophasm -k 15 -i f1.fa -o g1.fa\n" <<
-		"             - re-assemble f1 to g1\n" <<
-		"\n" <<
-		"Command-line parameters:\n" <<
-		" -k INT   K-mer size.\n" <<
-		" -i FILE  Input FASTA file (can be used multiple times).\n" <<
-		" -o FILE  Output FASTA file (if used, must be used as many times as -i).\n" <<
-		" -x FILE  Compute intersection, subtract it, save it.\n" <<
-		" -s FILE  Output file with k-mer statistics.\n" <<
-		//" -k INT   K-mer size. [" << default_k << "]\n" <<
-		" -S       Silent mode.\n" <<
-		"\n" <<
-		"Note that '-' can be used for standard input/output. \n" <<
-		std::endl;
+void print_help() {
+    std::cerr << "\n"
+              << "Program:  prophasm (a greedy assembler for k-mer set compression)\n"
+              << "Version:  " VERSION "\n"
+              << "Contact:  Karel Brinda <karel.brinda@hms.harvard.edu>\n"
+              << "\n"
+              << "Usage:    prophasm [options]\n"
+              << "\n"
+              << "Examples: prophasm -k 15 -i f1.fa -i f2.fa -x fx.fa\n"
+              << "             - compute intersection of f1 and f2\n"
+              << "          prophasm -k 15 -i f1.fa -i f2.fa -x fx.fa -o g1.fa -o g2.fa\n"
+              << "             - compute intersection of f1 and f2, and subtract it from them\n"
+              << "          prophasm -k 15 -i f1.fa -o g1.fa\n"
+              << "             - re-assemble f1 to g1\n"
+              << "\n"
+              << "Command-line parameters:\n"
+              << " -k INT   K-mer size.\n"
+              << " -i FILE  Input FASTA file (can be used multiple times).\n"
+              << " -o FILE  Output FASTA file (if used, must be used as many times as -i).\n"
+              << " -x FILE  Compute intersection, subtract it, save it.\n"
+              << " -s FILE  Output file with k-mer statistics.\n"
+              <<
+        //" -k INT   K-mer size. [" << default_k << "]\n" <<
+        " -S       Silent mode.\n"
+              << "\n"
+              << "Note that '-' can be used for standard input/output. \n"
+              << std::endl;
 }
 
-void test_file(FILE *fo, std::string fn){
-	if(fo==nullptr){
-		std::cerr << "Error: file '" << fn << "' could not be open (error " << errno << ", " << strerror(errno) << ")." << std::endl;
-		exit(1);
-	}
+void test_file(FILE *fo, std::string fn) {
+    if (fo == nullptr) {
+        std::cerr << "Error: file '" << fn << "' could not be open (error " << errno << ", "
+                  << strerror(errno) << ")." << std::endl;
+        exit(1);
+    }
 }
 
-template<typename _nkmer_T>
-int32_t encode_forward(const char *kmers, const int32_t k, _nkmer_T &nkmer){
-	nkmer=0;
-	for (int32_t i=0;i<k;i++){
-		uint8_t nt4 = nt256_nt4[static_cast<int32_t>(kmers[i])];
-		if (nt4==4){
-			return -1;
-		}
+template <typename _nkmer_T>
+int32_t encode_forward(const char *kmers, const int32_t k, _nkmer_T &nkmer) {
+    nkmer = 0;
+    for (int32_t i = 0; i < k; i++) {
+        uint8_t nt4 = nt256_nt4[static_cast<int32_t>(kmers[i])];
+        if (nt4 == 4) {
+            return -1;
+        }
 
-		nkmer <<= 2;
-		nkmer |= nt4;
-	}
-	return 0;
+        nkmer <<= 2;
+        nkmer |= nt4;
+    }
+    return 0;
 }
 
-template<typename _nkmer_T>
-int32_t encode_reverse(const char *kmers, const int32_t k, _nkmer_T &nkmer){
-	nkmer=0;
-	for (int32_t i=0;i<k;i++){
-		uint8_t nt4 = nt256_nt4[static_cast<int32_t>(kmers[k-i-1])];
-		if (nt4==4){
-			return -1;
-		}
+template <typename _nkmer_T>
+int32_t encode_reverse(const char *kmers, const int32_t k, _nkmer_T &nkmer) {
+    nkmer = 0;
+    for (int32_t i = 0; i < k; i++) {
+        uint8_t nt4 = nt256_nt4[static_cast<int32_t>(kmers[k - i - 1])];
+        if (nt4 == 4) {
+            return -1;
+        }
 
-		//complement
-		nt4 = 3-nt4;
+        // complement
+        nt4 = 3 - nt4;
 
-		nkmer <<= 2;
-		nkmer |= nt4;
-	}
-	return 0;
+        nkmer <<= 2;
+        nkmer |= nt4;
+    }
+    return 0;
 }
 
-template<typename _nkmer_T>
-int32_t encode_canonical(const char *kmers, const int32_t k, _nkmer_T &nkmer){
-	_nkmer_T nkmer_f;
-	_nkmer_T nkmer_r;
+template <typename _nkmer_T>
+int32_t encode_canonical(const char *kmers, const int32_t k, _nkmer_T &nkmer) {
+    _nkmer_T nkmer_f;
+    _nkmer_T nkmer_r;
 
-	int32_t error_code;
+    int32_t error_code;
 
-	error_code=encode_forward(kmers, k, nkmer_f);
-	if(error_code!=0){
-		return error_code;
-	}
+    error_code = encode_forward(kmers, k, nkmer_f);
+    if (error_code != 0) {
+        return error_code;
+    }
 
-	error_code=encode_reverse(kmers, k, nkmer_r);
-	if(error_code!=0){
-		return error_code;
-	}
+    error_code = encode_reverse(kmers, k, nkmer_r);
+    if (error_code != 0) {
+        return error_code;
+    }
 
-	nkmer=std::min(nkmer_f,nkmer_r);
+    nkmer = std::min(nkmer_f, nkmer_r);
 
-	return 0;
+    return 0;
 }
 
-template<typename _nkmer_T>
-int32_t decode_kmer(_nkmer_T nkmer, int32_t k, std::string &kmer){
-	kmer.resize(k);
-	for(int32_t i=0;i<k;i++){
-		uint8_t nt4 = nkmer & 0x3;
-		nkmer >>=2;
-		kmer[k-i-1]=nt4_nt256[nt4];
-	}
+template <typename _nkmer_T>
+int32_t decode_kmer(_nkmer_T nkmer, int32_t k, std::string &kmer) {
+    kmer.resize(k);
+    for (int32_t i = 0; i < k; i++) {
+        uint8_t nt4 = nkmer & 0x3;
+        nkmer >>= 2;
+        kmer[k - i - 1] = nt4_nt256[nt4];
+    }
 
-	return 0;
+    return 0;
 }
 
-void reverse_complement_in_place(std::string &kmer){
-	//std::cerr << "before reverse complementing " << kmer << std::endl;
+void reverse_complement_in_place(std::string &kmer) {
+    // std::cerr << "before reverse complementing " << kmer << std::endl;
     std::reverse(kmer.begin(), kmer.end());
-	for (int32_t i=0;i<static_cast<int32_t>(kmer.size());i++){
-		char nt4=nt256_nt4[static_cast<int32_t>(kmer[i])];
-		if (nt4<4){
-			nt4=3-nt4;
-		}
-		kmer[i]=nt4_nt256[static_cast<int32_t>(nt4)];
-	}
-	//std::cerr << "after reverse complementing " << kmer << std::endl;
+    for (int32_t i = 0; i < static_cast<int32_t>(kmer.size()); i++) {
+        char nt4 = nt256_nt4[static_cast<int32_t>(kmer[i])];
+        if (nt4 < 4) {
+            nt4 = 3 - nt4;
+        }
+        kmer[i] = nt4_nt256[static_cast<int32_t>(nt4)];
+    }
+    // std::cerr << "after reverse complementing " << kmer << std::endl;
 }
 
-template<typename _set_T>
-void debug_print_kmer_set(_set_T &set, int k, bool verbose){
-	std::string kmer;
-	for(auto x: set){
-		decode_kmer(x, k, kmer);
-		if(verbose){
-			std::cerr << x << " " << kmer << ";  ";
-		}
-	}
-	if(verbose){
-		std::cerr<<std::endl;
-	}
+template <typename _set_T>
+void debug_print_kmer_set(_set_T &set, int k, bool verbose) {
+    std::string kmer;
+    for (auto x : set) {
+        decode_kmer(x, k, kmer);
+        if (verbose) {
+            std::cerr << x << " " << kmer << ";  ";
+        }
+    }
+    if (verbose) {
+        std::cerr << std::endl;
+    }
 }
 
+struct simplitig_t {
+    int32_t k;
 
-struct simplitig_t{
-	int32_t k;
+    /* simplitig buffer */
+    char *seq_buffer;
 
-	/* simplitig buffer */
-	char *seq_buffer;
+    /* the first position of the simplitig */
+    char *l_ext;
 
-	/* the first position of the simplitig */
-	char *l_ext;
+    /* the last position of the simplitig +1 (semiopen ) */
+    char *r_ext;
 
-	/* the last position of the simplitig +1 (semiopen ) */
-	char *r_ext;
+    /* min possible value of l_ext */
+    char *l_ext_border;
 
-	/* min possible value of l_ext */
-	char *l_ext_border;
+    /* max possible value of l_ext */
+    char *r_ext_border;
 
-	/* max possible value of l_ext */
-	char *r_ext_border;
+    simplitig_t(uint32_t _k) {
+        this->k      = _k;
+        seq_buffer   = new char[k + 2 * max_simplitig_length + 1]();
+        l_ext_border = seq_buffer;
+        r_ext_border = seq_buffer + 2 * max_simplitig_length;
+    }
 
-	simplitig_t(uint32_t _k){
-		this->k=_k;
-		seq_buffer=new char[k+2*max_simplitig_length+1]();
-		l_ext_border=seq_buffer;
-		r_ext_border=seq_buffer+2*max_simplitig_length;
-	}
+    int32_t new_simplitig(const char *base_kmer) {
+        assert(static_cast<int32_t>(strlen(base_kmer)) == k);
 
-	int32_t new_simplitig(const char *base_kmer){
-		assert(static_cast<int32_t>(strlen(base_kmer))==k);
+        l_ext = r_ext = &seq_buffer[max_simplitig_length];
+        *r_ext        = '\0';
 
-		l_ext = r_ext = &seq_buffer[max_simplitig_length];
-		*r_ext='\0';
+        for (int32_t i = 0; i < k; i++) {
+            r_extend(base_kmer[i]);
+        }
+        return 0;
+    }
 
-		for(int32_t i=0;i<k;i++){
-			r_extend(base_kmer[i]);
-		}
-		return 0;
-	}
+    int32_t r_extend(char c) {
+        uint8_t nt4 = nt256_nt4[static_cast<int32_t>(c)];
 
-	int32_t r_extend(char c){
-		uint8_t nt4 = nt256_nt4[static_cast<int32_t>(c)];
+        if (nt4 == 4) {
+            return -1;
+        }
 
-		if (nt4==4){
-			return -1;
-		}
+        *r_ext = nt4_nt256[nt4];
+        ++r_ext;
+        *r_ext = '\0';
+        return 0;
+    }
 
-		*r_ext=nt4_nt256[nt4];
-		++r_ext;
-		*r_ext='\0';
-		return 0;
-	}
+    int32_t l_extend(char c) {
+        uint8_t nt4 = nt256_nt4[static_cast<int32_t>(c)];
 
-	int32_t l_extend(char c){
-		uint8_t nt4 = nt256_nt4[static_cast<int32_t>(c)];
+        if (nt4 == 4) {
+            return -1;
+        }
 
-		if (nt4==4){
-			return -1;
-		}
+        --l_ext;
+        *l_ext = nt4_nt256[3 - nt4];
+        return 0;
+    }
 
-		--l_ext;
-		*l_ext=nt4_nt256[3-nt4];
-		return 0;
-	}
+    ~simplitig_t() { delete[] seq_buffer; }
 
-	~simplitig_t(){
-		delete[] seq_buffer;
-	}
+    bool is_full() { return (r_ext >= r_ext_border) || (l_ext <= l_ext_border); }
 
-	bool is_full(){
-		return (r_ext>=r_ext_border) || (l_ext<=l_ext_border);
-	}
+    int32_t print_to_fasta(FILE *fasta_file, const char *simplitig_name,
+                           const char *comment = nullptr) const {
+        if (comment == nullptr) {
+            fprintf(fasta_file, ">%s\n", simplitig_name);
+        } else {
+            fprintf(fasta_file, ">%s %s\n", simplitig_name, comment);
+        }
 
-	int32_t print_to_fasta(FILE* fasta_file, const char* simplitig_name, const char *comment=nullptr) const {
-		if (comment==nullptr){
-			fprintf(fasta_file,">%s\n",simplitig_name);
-		} else {
-			fprintf(fasta_file,">%s %s\n",simplitig_name,comment);
-		}
+        char print_buffer[fasta_line_length + 1] = {0};
 
-		char print_buffer[fasta_line_length+1]={0};
+        for (char *p = l_ext; p < r_ext; p += fasta_line_length) {
+            strncpy(print_buffer, p, fasta_line_length);
+            fprintf(fasta_file, "%s\n", print_buffer);
+        }
 
-		for (char *p=l_ext;p<r_ext;p+=fasta_line_length){
-			strncpy(print_buffer,p,fasta_line_length);
-			fprintf(fasta_file, "%s\n", print_buffer);
-		}
-
-		return 0;
-	}
+        return 0;
+    }
 };
 
-
 /*
-	TODO: test if kmer is correct
+        TODO: test if kmer is correct
 */
 
-//template<typename _nkmer_T, typename _set_T>
-template<typename _set_T>
-int kmers_from_fasta(const std::string &fasta_fn, _set_T &set, int32_t k, FILE* fstats,bool verbose){
+// template<typename _nkmer_T, typename _set_T>
+template <typename _set_T>
+int kmers_from_fasta(const std::string &fasta_fn, _set_T &set, int32_t k, FILE *fstats,
+                     bool verbose) {
+    if (verbose) {
+        std::cerr << "Loading " << fasta_fn << std::endl;
+    }
 
-	if (verbose){
-		std::cerr << "Loading " << fasta_fn << std::endl;
-	}
+    set.clear();
 
-	set.clear();
+    kseq_t *seq;
+    int64_t l;
 
-	kseq_t *seq;
-	int64_t l;
+    FILE *instream = nullptr;
+    if (fasta_fn == "-") {
+        instream = stdin;
+    } else {
+        instream = fopen(fasta_fn.c_str(), "r");
+        test_file(instream, fasta_fn);
+    }
+    gzFile fp = gzdopen(fileno(instream), "r");
+    seq       = kseq_init(fp);
 
-	FILE *instream = nullptr;
-	if(fasta_fn=="-"){
-		instream = stdin;
-	}
-	else {
-		instream = fopen(fasta_fn.c_str(), "r");
-		test_file(instream, fasta_fn);
-	}
-	gzFile fp = gzdopen(fileno(instream), "r");
-	seq = kseq_init(fp);
+    typename _set_T::value_type nkmer;
 
-	typename _set_T::value_type nkmer;
+    for (int32_t seqid = 0; (l = kseq_read(seq)) >= 0; seqid++) {
+        // std::cerr << "kmers from fasta" << std::endl;
 
-	for(int32_t seqid=0;(l = kseq_read(seq)) >= 0;seqid++) {
-		//std::cerr << "kmers from fasta" << std::endl;
+        // std::cerr << "starting iterator" << std::endl;
+        for (char *kmer = seq->seq.s; kmer < (seq->seq.s) + (seq->seq.l) - k + 1; kmer++) {
+            int c = encode_canonical(kmer, k, nkmer);
+            if (c == 0) {
+                set.insert(nkmer);
+            } else {
+                // std::cerr << "problem" <<std::endl;
+            }
+        }
+    }
 
-		//std::cerr << "starting iterator" << std::endl;
-		for(char *kmer=seq->seq.s; kmer < (seq->seq.s) + (seq->seq.l) -k +1 ;kmer++){
-			int c = encode_canonical(kmer, k, nkmer);
-			if (c==0){
-				set.insert(nkmer);
-			}
-			else{
-				//std::cerr << "problem" <<std::endl;
-			}
-		}
-	}
+    if (fstats) {
+        fprintf(fstats, "%s\t%lu\n", fasta_fn.c_str(), set.size());
+    }
+    // std::cerr << "iterator finished" << std::endl;
 
-	if(fstats){
-		fprintf(fstats,"%s\t%lu\n",fasta_fn.c_str(),set.size());
-	}
-	//std::cerr << "iterator finished" << std::endl;
+    kseq_destroy(seq);
+    gzclose(fp);
 
-	kseq_destroy(seq);
-	gzclose(fp);
-
-	return 0;
+    return 0;
 }
 
-template<typename _set_T>
-int32_t find_intersection(const std::vector<_set_T> &sets, _set_T &intersection){
-	assert(sets.size()>0);
+template <typename _set_T>
+int32_t find_intersection(const std::vector<_set_T> &sets, _set_T &intersection) {
+    assert(sets.size() > 0);
 
-	/*
-		1) Find the smallest set from sets.
-	*/
+    /*
+            1) Find the smallest set from sets.
+    */
 
-	int32_t min=std::numeric_limits<int32_t>::max();
-	int32_t i_min=-1;
+    int32_t min   = std::numeric_limits<int32_t>::max();
+    int32_t i_min = -1;
 
-	//std::cerr << "searching min" << std::endl;
+    // std::cerr << "searching min" << std::endl;
 
-	for(int32_t i=0;i<static_cast<int32_t>(sets.size());i++){
-		if (static_cast<int32_t>(sets[i].size())<min){
-			min=sets[i].size();
-			i_min=i;
-			//std::cerr << "new min" << i << std::endl;
-		}
-	}
+    for (int32_t i = 0; i < static_cast<int32_t>(sets.size()); i++) {
+        if (static_cast<int32_t>(sets[i].size()) < min) {
+            min   = sets[i].size();
+            i_min = i;
+            // std::cerr << "new min" << i << std::endl;
+        }
+    }
 
-	assert(i_min != std::numeric_limits<int32_t>::max() && i_min!=-1);
+    assert(i_min != std::numeric_limits<int32_t>::max() && i_min != -1);
 
-	/*
-		2) Take it as the intersection.
-	*/
+    /*
+            2) Take it as the intersection.
+    */
 
-	//std::cerr << "2" << std::endl;
+    // std::cerr << "2" << std::endl;
 
-	intersection.clear();
-	//std::cerr << "2.1" << std::endl;
-	std::copy(
-		sets[i_min].cbegin(), sets[i_min].cend(),
-		std::inserter(intersection,intersection.end())
-	);
+    intersection.clear();
+    // std::cerr << "2.1" << std::endl;
+    std::copy(sets[i_min].cbegin(), sets[i_min].cend(),
+              std::inserter(intersection, intersection.end()));
 
-	/*
-		3) Remove elements from intersection present in other sets.
-	*/
+    /*
+            3) Remove elements from intersection present in other sets.
+    */
 
-	for(const _set_T &current_set : sets) {
+    for (const _set_T &current_set : sets) {
+        for (auto it = intersection.begin(); it != intersection.end();) {
+            if (current_set.find(*it) == current_set.cend()) {
+                it = intersection.erase(it);
+            } else {
+                ++it;
+            }
+        }
+    }
 
-		for(auto it = intersection.begin(); it !=intersection.end();){
-
-			if(current_set.find(*it) == current_set.cend()){
-				it=intersection.erase(it);
-			}
-			else{
-				++it;
-			}
-		}
-	}
-
-	return 0;
+    return 0;
 }
 
+template <typename _set_T, typename _subset_T>
+int32_t remove_subset(std::vector<_set_T> &sets, const _subset_T &subset) {
+    for (int32_t i = 0; i < static_cast<int32_t>(sets.size()); i++) {
+        _set_T &current_set = sets[i];
 
-template<typename _set_T, typename _subset_T>
-int32_t remove_subset(std::vector<_set_T> &sets, const _subset_T &subset){
+        for (const auto &nkmer : subset) {
+            current_set.erase(nkmer);
+        }
+    }
 
-	for(int32_t i=0;i<static_cast<int32_t>(sets.size());i++){
-
-		_set_T &current_set = sets[i];
-
-		for(const auto &nkmer : subset){
-			current_set.erase(nkmer);
-		}
-	}
-
-	return 0;
+    return 0;
 }
 
+template <typename _set_T>
+int assemble(const std::string &fasta_fn, _set_T &set, int32_t k, FILE *fstats, bool verbose) {
+    if (fstats) {
+        fprintf(fstats, "%s\t%lu\n", fasta_fn.c_str(), set.size());
+    }
 
-template<typename _set_T>
-int assemble(const std::string &fasta_fn, _set_T &set, int32_t k, FILE* fstats, bool verbose){
-	if(fstats){
-		fprintf(fstats,"%s\t%lu\n",fasta_fn.c_str(),set.size());
-	}
+    FILE *file = nullptr;
+    if (fasta_fn == "-") {
+        file = stdout;
+    } else {
+        file = fopen(fasta_fn.c_str(), "w+");
+        test_file(file, fasta_fn);
+    }
+    char kmer_str[max_allowed_kmer_length + 1];
+    simplitig_t simplitig(k);
+    const std::vector<char> nucls = {'A', 'C', 'G', 'T'};
 
-	FILE *file=nullptr;
-	if(fasta_fn=="-"){
-		file=stdout;
-	}
-	else{
-		file=fopen(fasta_fn.c_str(),"w+");
-		test_file(file, fasta_fn);
-	}
-	char kmer_str[max_allowed_kmer_length+1];
-	simplitig_t simplitig(k);
-	const std::vector<char> nucls = {'A','C','G','T'};
+    // int32_t i=0;
+    int32_t simplitig_id = 1;
+    while (set.size() > 0) {
+        const auto central_nkmer = *(set.begin());
+        set.erase(central_nkmer);
 
-	//int32_t i=0;
-	int32_t simplitig_id=1;
-	while(set.size()>0){
+        std::string central_kmer_string;
+        decode_kmer(central_nkmer, k, central_kmer_string);
+        simplitig.new_simplitig(central_kmer_string.c_str());
 
-		const auto central_nkmer=*(set.begin());
-		set.erase(central_nkmer);
+        typename _set_T::value_type nkmer;
 
-		std::string central_kmer_string;
-		decode_kmer(central_nkmer,k,central_kmer_string);
-		simplitig.new_simplitig(central_kmer_string.c_str());
+        for (int direction = 0; direction < 2; direction++) {
+            // std::cerr << "direction " << direction << std::endl;
 
-		typename _set_T::value_type nkmer;
+            if (direction == 0) {
+                // forward
+            } else {
+                // reverse
+                reverse_complement_in_place(central_kmer_string);
+            }
 
+            strncpy(kmer_str, central_kmer_string.c_str(), k);
+            kmer_str[k] = '\0';
 
-		for (int direction=0;direction<2;direction++){
+            bool extending = true;
 
-			//std::cerr << "direction " << direction << std::endl;
+            // std::cerr << "central k-mer: " << central_kmer_string << std::endl;
 
-			if (direction==0){
-				// forward
-			}
-			else{
-				// reverse
-				reverse_complement_in_place(central_kmer_string);
-			}
+            while (extending) {
+                for (int32_t i = 0; i < k; i++) {
+                    kmer_str[i] = kmer_str[i + 1];
+                }
+                kmer_str[k] = '\0';
 
-			strncpy(kmer_str,central_kmer_string.c_str(),k);
-			kmer_str[k]='\0';
+                extending = false;
+                for (const char &c : nucls) {
+                    kmer_str[k - 1] = c;
 
-			bool extending = true;
+                    encode_canonical(kmer_str, k, nkmer);
 
-			//std::cerr << "central k-mer: " << central_kmer_string << std::endl;
+                    if (set.count(nkmer)) {
+                        // std::cerr << "extending " << c << std::endl;
+                        // debug_print_kmer_set(set,k);
+                        // std::cerr << std::string(simplitig.l_ext) << c << std::endl;
+                        // std::cerr << std::endl;
+                        if (direction == 0) {
+                            simplitig.r_extend(c);
+                        } else {
+                            simplitig.l_extend(c);
+                        }
+                        set.erase(nkmer);
 
+                        if (!simplitig.is_full()) {
+                            extending = true;
+                        }
+                        break;
+                    }
+                }
+            }
+        }
 
-			while (extending){
-				for(int32_t i=0;i<k;i++){
-					kmer_str[i]=kmer_str[i+1];
-				}
-				kmer_str[k]='\0';
+        // std::cerr << "====================" << std::endl;
 
-				extending=false;
-				for(const char &c : nucls){
-					kmer_str[k-1]=c;
+        std::stringstream ss;
+        ss << "c" << simplitig_id;
+        const std::string simplitig_name(ss.str());
+        simplitig.print_to_fasta(file, simplitig_name.c_str());
+        simplitig_id++;
+    }
 
-					encode_canonical(kmer_str, k, nkmer);
+    fclose(file);
 
-					if(set.count( nkmer )){
-						//std::cerr << "extending " << c << std::endl;
-						//debug_print_kmer_set(set,k);
-						//std::cerr << std::string(simplitig.l_ext) << c << std::endl;
-						//std::cerr << std::endl;
-						if(direction==0){
-							simplitig.r_extend(c);
-						}
-						else{
-							simplitig.l_extend(c);
-						}
-						set.erase(nkmer);
+    if (verbose) {
+        std::cerr << "   assembly finished (" << simplitig_id << " simplitigs)" << std::endl;
+    }
 
-						if(!simplitig.is_full()){
-							extending=true;
-						}
-						break;
-					}
-				}
-			}
-		}
-
-		//std::cerr << "====================" << std::endl;
-
-		std::stringstream ss;
-		ss<<"c"<<simplitig_id;
-		const std::string simplitig_name(ss.str());
-		simplitig.print_to_fasta(file,simplitig_name.c_str());
-		simplitig_id++;
-	}
-
-	fclose(file);
-
-	if(verbose){
-		std::cerr << "   assembly finished (" << simplitig_id << " simplitigs)" << std::endl;
-	}
-
-	return 0;
-
+    return 0;
 }
 
+int main(int argc, char *argv[]) {
+    int32_t k = -1;
 
-int main (int argc, char* argv[])
-{
-	int32_t k=-1;
+    std::string intersection_fn;
+    std::vector<std::string> in_fns;
+    std::vector<std::string> out_fns;
+    std::string stats_fn;
+    FILE *fstats = nullptr;
 
-	std::string intersection_fn;
-	std::vector<std::string> in_fns;
-	std::vector<std::string> out_fns;
-	std::string stats_fn;
-	FILE *fstats=nullptr;
+    if (argc < 2) {
+        print_help();
+        exit(1);
+    }
 
-	if (argc<2){
-		print_help();
-		exit(1);
-	}
+    bool compute_intersection = false;
+    bool compute_output       = false;
+    bool verbose              = true;
+    int32_t no_sets           = 0;
 
-	bool compute_intersection=false;
-	bool compute_output=false;
-	bool verbose=true;
-	int32_t no_sets=0;
+    int c;
+    while ((c = getopt(argc, (char *const *)argv, "hSi:o:x:s:k:")) >= 0) {
+        switch (c) {
+            case 'h': {
+                print_help();
+                exit(0);
+                break;
+            }
+            case 'i': {
+                in_fns.push_back(std::string(optarg));
+                no_sets += 1;
+                break;
+            }
+            case 'o': {
+                out_fns.push_back(std::string(optarg));
+                compute_output = true;
+                break;
+            }
+            case 'x': {
+                intersection_fn      = std::string(optarg);
+                compute_intersection = true;
+                break;
+            }
+            case 's': {
+                stats_fn = std::string(optarg);
+                if (stats_fn == "-") {
+                    fstats = stdin;
+                } else {
+                    fstats = fopen(stats_fn.c_str(), "w+");
+                    test_file(fstats, stats_fn);
+                }
 
-	int c;
-	while ((c = getopt(argc, (char *const *)argv, "hSi:o:x:s:k:")) >= 0) {
-		switch (c) {
-			case 'h': {
-				print_help();
-				exit(0);
-				break;
-			}
-			case 'i': {
-				in_fns.push_back(std::string(optarg));
-				no_sets+=1;
-				break;
-			}
-			case 'o': {
-				out_fns.push_back(std::string(optarg));
-				compute_output=true;
-				break;
-			}
-			case 'x': {
-				intersection_fn=std::string(optarg);
-				compute_intersection=true;
-				break;
-			}
-			case 's': {
-				stats_fn=std::string(optarg);
-				if(stats_fn=="-"){
-					fstats = stdin;
-				}
-				else {
-					fstats = fopen(stats_fn.c_str(), "w+");
-					test_file(fstats, stats_fn);
-				}
+                break;
+            }
+            case 'S': {
+                verbose = false;
 
-				break;
-			}
-			case 'S': {
-				verbose=false;
+                break;
+            }
+            case 'k': {
+                k = atoi(optarg);
+                break;
+            }
+            case '?': {
+                std::cerr << "Unknown error" << std::endl;
+                exit(1);
+                break;
+            }
+        }
+    }
 
-				break;
-			}
-			case 'k': {
-				k = atoi(optarg);
-				break;
-			}
-			case '?': {
-				std::cerr<<"Unknown error"<<std::endl;
-				exit(1);
-				break;
-			}
-		}
-	}
+    if (k == -1) {
+        print_help();
+        std::cerr << "K-mer size (-k) is required." << std::endl;
+        return EXIT_FAILURE;
+    }
 
-	if (k == -1){
-		print_help();
-		std::cerr << "K-mer size (-k) is required." << std::endl;
-		return EXIT_FAILURE;
-	}
+    if (k <= 0 || max_allowed_kmer_length < k) {
+        std::cerr << "K-mer size must satisfy 1 <= k <= " << max_allowed_kmer_length << "."
+                  << std::endl;
+        return EXIT_FAILURE;
+    }
 
+    if (compute_output && (static_cast<int32_t>(out_fns.size()) != no_sets)) {
+        std::cerr << "If -o is used, it must be used as many times as -i (" << no_sets
+                  << "!=" << out_fns.size() << ")." << std::endl;
+        return EXIT_FAILURE;
+    }
 
-	if (k <= 0 || max_allowed_kmer_length<k){
-		std::cerr << "K-mer size must satisfy 1 <= k <= " << max_allowed_kmer_length << "." << std::endl;
-		return EXIT_FAILURE;
-	}
+    if (fstats) {
+        fprintf(fstats, "# cmd: %s", argv[0]);
 
-	if (compute_output && (static_cast<int32_t>(out_fns.size())!=no_sets)){
-		std::cerr << "If -o is used, it must be used as many times as -i (" << no_sets << "!=" << out_fns.size() << ")." << std::endl;
-		return EXIT_FAILURE;
-	}
+        for (int32_t i = 1; i < argc; i++) {
+            fprintf(fstats, " %s", argv[i]);
+        }
+        fprintf(fstats, "\n");
+    }
 
-	if(fstats){
-		fprintf(fstats,"# cmd: %s",argv[0]);
+    std::vector<std::unordered_set<nkmer_t>> full_sets(no_sets);
 
-		for (int32_t i=1;i<argc;i++){
-			fprintf(fstats," %s",argv[i]);
-		}
-		fprintf(fstats,"\n");
-	}
+    if (verbose) {
+        std::cerr << "=====================" << std::endl;
+        std::cerr << "1) Loading references" << std::endl;
+        std::cerr << "=====================" << std::endl;
+    }
 
-	std::vector< std::unordered_set<nkmer_t> > full_sets(no_sets);
+    std::vector<int32_t> in_sizes;
+    std::vector<int32_t> out_sizes;
 
-	if(verbose){
-		std::cerr << "=====================" << std::endl;
-		std::cerr << "1) Loading references" << std::endl;
-		std::cerr << "=====================" << std::endl;
-	}
+    for (int32_t i = 0; i < no_sets; i++) {
+        kmers_from_fasta(in_fns[i], full_sets[i], k, fstats, verbose);
+        // debug_print_kmer_set(full_sets[i],k);
+        in_sizes.insert(in_sizes.end(), full_sets[i].size());
+    }
 
+    if (verbose) {
+        std::cerr << "===============" << std::endl;
+        std::cerr << "2) Intersecting" << std::endl;
+        std::cerr << "===============" << std::endl;
+    }
 
-	std::vector<int32_t> in_sizes;
-	std::vector<int32_t> out_sizes;
+    std::unordered_set<nkmer_t> intersection;
 
-	for(int32_t i=0;i<no_sets;i++){
-		kmers_from_fasta(in_fns[i],full_sets[i],k,fstats,verbose);
-		//debug_print_kmer_set(full_sets[i],k);
-		in_sizes.insert(in_sizes.end(),full_sets[i].size());
-	}
+    int32_t intersection_size = 0;
 
-	if(verbose){
-		std::cerr << "===============" << std::endl;
-		std::cerr << "2) Intersecting" << std::endl;
-		std::cerr << "===============" << std::endl;
-	}
+    if (compute_intersection) {
+        if (verbose) {
+            std::cerr << "2.1) Computing intersection" << std::endl;
+        }
 
+        find_intersection(full_sets, intersection);
+        intersection_size = intersection.size();
+        if (verbose) {
+            std::cerr << "   intersection size: " << intersection_size << std::endl;
+        }
+        if (compute_output) {
+            if (verbose) {
+                std::cerr << "2.2) Removing this intersection from all kmer sets" << std::endl;
+            }
+            remove_subset(full_sets, intersection);
+        }
+    }
 
-	std::unordered_set<nkmer_t> intersection;
+    if (compute_output) {
+        for (int32_t i = 0; i < no_sets; i++) {
+            out_sizes.insert(out_sizes.end(), full_sets[i].size());
+            assert(in_sizes[i] == out_sizes[i] + intersection_size);
+            if (verbose) {
+                std::cerr << in_sizes[i] << " " << out_sizes[i] << " ...inter:" << intersection_size
+                          << std::endl;
+            }
+        }
+    }
 
-	int32_t intersection_size = 0;
+    if (verbose) {
+        std::cerr << "=============" << std::endl;
+        std::cerr << "3) Assembling" << std::endl;
+        std::cerr << "=============" << std::endl;
+    }
 
-	if(compute_intersection){
-		if (verbose){
-			std::cerr << "2.1) Computing intersection" << std::endl;
-		}
+    if (compute_output) {
+        for (int32_t i = 0; i < static_cast<int32_t>(in_fns.size()); i++) {
+            assemble(out_fns[i], full_sets[i], k, fstats, verbose);
+        }
+    }
+    if (compute_intersection) {
+        assemble(intersection_fn, intersection, k, fstats, verbose);
+    }
 
-		find_intersection(full_sets, intersection);
-		intersection_size  = intersection.size();
-		if (verbose){
-			std::cerr << "   intersection size: " <<  intersection_size << std::endl;
-		}
-		if(compute_output){
-			if (verbose){
-				std::cerr << "2.2) Removing this intersection from all kmer sets" << std::endl;
-			}
-			remove_subset(full_sets, intersection);
-		}
-	}
+    if (fstats) {
+        fclose(fstats);
+    }
 
-	if(compute_output){
-		for (int32_t i=0;i<no_sets;i++){
-			out_sizes.insert(out_sizes.end(),full_sets[i].size());
-			assert(in_sizes[i]==out_sizes[i]+intersection_size);
-			if (verbose){
-				std::cerr << in_sizes[i] << " " << out_sizes[i] << " ...inter:" << intersection_size << std::endl;
-			}
-		}
-	}
-
-	if(verbose){
-		std::cerr << "=============" << std::endl;
-		std::cerr << "3) Assembling" << std::endl;
-		std::cerr << "=============" << std::endl;
-	}
-
-	if(compute_output){
-		for(int32_t i=0;i<static_cast<int32_t>(in_fns.size());i++){
-			assemble(out_fns[i], full_sets[i], k, fstats, verbose);
-		}
-	}
-	if(compute_intersection){
-		assemble(intersection_fn, intersection, k, fstats, verbose);
-	}
-
-	if (fstats){
-		fclose(fstats);
-	}
-
-	return 0;
+    return 0;
 }

--- a/src/prophasm.cpp
+++ b/src/prophasm.cpp
@@ -110,7 +110,7 @@ void print_help() {
         << " -o FILE  output FASTA file (if used, must be used as many times as -i)\n"
         << " -x FILE  compute intersection, subtract it, save it\n"
         << " -s FILE  output file with k-mer statistics\n"
-        << " -s       silent mode\n"
+        << " -S       silent mode\n"
         << "\n"
         << "Note that '-' can be used for standard input/output. \n"
         << std::endl;

--- a/src/prophasm.cpp
+++ b/src/prophasm.cpp
@@ -1,7 +1,7 @@
 /*
 	The MIT License
 
-	Copyright (c) 2016-2017 Karel Brinda <kbrinda@hsph.harvard.edu>
+	Copyright (c) 2016-2020 Karel Brinda <karel.brinda@hms.harvard.edu>
 
 	Permission is hereby granted, free of charge, to any person obtaining
 	a copy of this software and associated documentation files (the
@@ -29,14 +29,13 @@
 Description:
 
 	Get k-mer sets from FASTA files, extract the intersection, and
-	assemble all the resulting k-mer sets into contigs. The assembly is
+	assemble all the resulting k-mer sets into simplitigs. The assembly is
 	done by greedy enumeration of disjoint paths in the corresponding
 	de-Bruijn graphs.
 
 Todo:
 	* Find a library for sets of integers bigger than uint64_t (to support k-mers longer than 32).
 	* Optimize loading FASTA files.
-	* Check memory consumption (and put it here).
 */
 #include "kseq.h"
 #include "version.h"
@@ -94,7 +93,7 @@ void print_help(){
 		"\n" <<
 		"Program:  prophasm (a greedy assembler for k-mer set compression)\n" <<
 		"Version:  " VERSION "\n" <<
-		"Contact:  Karel Brinda <kbrinda@hsph.harvard.edu>\n" <<
+		"Contact:  Karel Brinda <karel.brinda@hms.harvard.edu>\n" <<
 		"\n" <<
 		"Usage:    prophasm [options]\n" <<
 		"\n" <<

--- a/src/prophasm.cpp
+++ b/src/prophasm.cpp
@@ -1,30 +1,4 @@
 /*
-        The MIT License
-
-        Copyright (c) 2016-2020 Karel Brinda <karel.brinda@hms.harvard.edu>
-
-        Permission is hereby granted, free of charge, to any person obtaining
-        a copy of this software and associated documentation files (the
-        "Software"), to deal in the Software without restriction, including
-        without limitation the rights to use, copy, modify, merge, publish,
-        distribute, sublicense, and/or sell copies of the Software, and to
-        permit persons to whom the Software is furnished to do so, subject to
-        the following conditions:
-
-        The above copyright notice and this permission notice shall be
-        included in all copies or substantial portions of the Software.
-
-        THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-        EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-        MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-        NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
-        BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
-        ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-        CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-        SOFTWARE.
-*/
-
-/*
 
 Description:
 
@@ -93,7 +67,7 @@ void print_help() {
         << "\n"
         << "Program:  prophasm (computation of simplitigs and k-mer set operations)\n"
         << "Version:  " VERSION "\n"
-        << "Contact:  Karel Brinda <karel.brinda@hms.harvard.edu>\n"
+        << "Contact:  Karel Brinda <karel.brinda@inria.fr>\n"
         << "\n"
         << "Usage:    prophasm [options]\n"
         << "\n"

--- a/src/prophasm.cpp
+++ b/src/prophasm.cpp
@@ -90,7 +90,7 @@ KSEQ_INIT(gzFile, gzread)
 
 void print_help() {
     std::cerr << "\n"
-              << "Program:  prophasm (a greedy assembler for k-mer set compression)\n"
+              << "Program:  prophasm (computation of simplitigs and k-mer set operations)\n"
               << "Version:  " VERSION "\n"
               << "Contact:  Karel Brinda <karel.brinda@hms.harvard.edu>\n"
               << "\n"

--- a/src/version.h
+++ b/src/version.h
@@ -1,2 +1,2 @@
-#define VERSION "0.1.1"
+#define VERSION "0.1.2"
 

--- a/src/version.h
+++ b/src/version.h
@@ -1,2 +1,2 @@
-#define VERSION "0.1.0"
+#define VERSION "0.1.1"
 

--- a/tests/tools/fa_norm.py
+++ b/tests/tools/fa_norm.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python3
 """Normalize a FASTA file (in order to compare different FASTA files).
 
-Author: Karel Brinda <kbrinda@hsph.harvard.edu>
+Author: Karel Brinda <karel.brinda@inria.fr>
 
 Licence: MIT
 """

--- a/tests/tools/fa_to_kmers.py
+++ b/tests/tools/fa_to_kmers.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python3
 """Compute k-mers from a FASTA file.
 
-Author: Karel Brinda <kbrinda@hsph.harvard.edu>
+Author: Karel Brinda <karel.brinda@inria.fr>
 
 Licence: MIT
 """

--- a/tests/tools/verify_output.py
+++ b/tests/tools/verify_output.py
@@ -2,7 +2,7 @@
 
 """A program to verify output of prophasm.
 
-Author: Karel Brinda <kbrinda@hsph.harvard.edu>
+Author: Karel Brinda <karel.brinda@inria.fr>
 
 Licence: MIT
 """


### PR DESCRIPTION
Updates
* Reformatting and refactoring (in particular, change the contig wording to the simplitig wording)
* If only 1 set is provided in the input, use a simplified execution without intersecting (todo: measure memory improvement)
* Always compute and subtract intersection (even if `-x` is not specified)
* Set `max_simplitig_length` to 10000000